### PR TITLE
Fix the deploy to EB

### DIFF
--- a/.github/workflows/aws-eb-deploy.yml
+++ b/.github/workflows/aws-eb-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y python3-pip
-          pip3 install --upgrade awscli==1.27.81 awsebcli==3.20.5
+          pip3 install --upgrade awsebcli==3.21.0
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
The installation of awsebcli was failing because of a conflict with awscli. The later is not needed, and after removing it, the install of the former succeeded.