### PR TITLE
Fix redeem opearation

### DIFF
--- a/packages/vusd-lib/src/index.js
+++ b/packages/vusd-lib/src/index.js
@@ -293,7 +293,7 @@ const createVusdLib = function (web3, options = {}) {
           method: minter.methods.mint(
             token,
             amount,
-            toMinAmount(amount),
+            toUnit(toMinAmount(amount), 18 - decimals), // token to VUSD
             owner
           ),
           suffix: 'mint'
@@ -362,7 +362,7 @@ const createVusdLib = function (web3, options = {}) {
           method: redeemer.methods.redeem(
             token,
             amount,
-            toMinAmount(amount),
+            fromUnit(toMinAmount(amount), 18 - decimals), // VUSD to token
             tokenReceiver || owner
           ),
           suffix: 'redeem'

--- a/packages/vusd-lib/src/index.js
+++ b/packages/vusd-lib/src/index.js
@@ -168,7 +168,7 @@ const createVusdLib = function (web3, options = {}) {
       .then(minter => minter.methods.mintingFee().call())
       .then(function (response) {
         const fee = Number.parseInt(response) / 10000
-        debug('Minting fee is %s%', (fee * 100).toFixed(2))
+        debug('Minting fee is %s', (fee * 100).toFixed(2))
         return fee
       })
   }
@@ -179,7 +179,7 @@ const createVusdLib = function (web3, options = {}) {
       .then(redeemer => redeemer.methods.redeemFee().call())
       .then(function (response) {
         const fee = Number.parseInt(response) / 10000
-        debug('Redeem fee is %s%', (fee * 100).toFixed(2))
+        debug('Redeem fee is %s', (fee * 100).toFixed(2))
         return fee
       })
   }


### PR DESCRIPTION
After the changes in the v1.4.2 of the contracts, both `mint()` and `redeem()` require the caller to specify the minimum amount to be received. This amount must be expressed in VUSD when minting and in the token units when redeeming.

The code to support the new parameters was introduced in #65 but the minimum amounts were expressed in the input token decimals, not the output one. Therefore the redeem operation for tokens with less than 18 decimals like USDT and USDC failed. Minting was successful but the required amount out was in excess.

This PR properly applies the decimals conversion to both operations.